### PR TITLE
Allow code buffer cursor positioning

### DIFF
--- a/src/code-buffer-vixl.h
+++ b/src/code-buffer-vixl.h
@@ -66,10 +66,21 @@ class CodeBuffer {
     return GetCursorOffset();
   }
 
+  void SetCursorOffset(ptrdiff_t offset) {
+    byte* rewound_cursor = buffer_ + offset;
+    cursor_ = rewound_cursor;
+  }
+
   void Rewind(ptrdiff_t offset) {
     byte* rewound_cursor = buffer_ + offset;
     VIXL_ASSERT((buffer_ <= rewound_cursor) && (rewound_cursor <= cursor_));
     cursor_ = rewound_cursor;
+  }
+
+  void CursorForward(ptrdiff_t offset) {
+    byte* forward_cursor = cursor_ + offset;
+    VIXL_ASSERT((buffer_ <= forward_cursor) && (forward_cursor >= cursor_));
+    cursor_ = forward_cursor;
   }
 
   template <typename T>


### PR DESCRIPTION
This is useful for when we want to move the code cursor forward with low
overhead.

eg: Loading code from file in to the same code buffer

Also when we want to move the cursor to a specific location inside the
code buffer

eg: Code relocations