### PR TITLE
CMake: Add a vixl::vixl ALIAS library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,3 +56,4 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   )
 endif()
 
+add_library(vixl::vixl ALIAS vixl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ if(CMAKE_BUILD_TYPE MATCHES DEBUG)
 endif()
 
 target_compile_options(vixl PRIVATE -ffunction-sections)
+target_include_directories(vixl PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 set_target_properties(vixl PROPERTIES C_VISIBILITY_PRESET hidden)
 set_target_properties(vixl PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(vixl PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)


### PR DESCRIPTION
This is needed for an upcoming PR that will remove the usage of global `include_directories` and instead propagate them via targets.

Signed-off-by: crueter <crueter@eden-emu.dev>
